### PR TITLE
use GitVersioning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.4.{build}
+version: build {build}
 image: Visual Studio 2017
 
 build:
@@ -7,20 +7,21 @@ build:
 init:
 - git config --global core.autocrlf input
 
+before_build:
+- ps: |
+    dotnet tool install nbgv --tool-path .paket
+    $env:SEMVER = .paket/nbgv get-version -v SemVer2
+    Update-AppveyorBuild -Version "$env:SEMVER ($env:APPVEYOR_BUILD_ID)"
+
 build_script:
 - ps: |
     $forceVersion = @()
     if ("$env:APPVEYOR_REPO_BRANCH" -match 'v?\d*\.\d*') {
       $forceVersion = "--force-version",$env:APPVEYOR_REPO_BRANCH
     }
-    .\build.cmd -t release -v "$env:APPVEYOR_BUILD_VERSION" --clean-test true $forceVersion
+    .\build.cmd -t release -v "$env:SEMVER" --clean-test true $forceVersion
 
 for:
-# Publish to NuGet only from Windows on master
-- branches:
-    only:
-    - master
-    - /v?\d*\.\d*/
   artifacts:
   - path: build\*.nupkg
     name: nuget

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ build_script:
     }
     .\build.cmd -t release -v "$env:SEMVER" --clean-test true $forceVersion
 
-for:
-  artifacts:
-  - path: build\*.nupkg
-    name: nuget
+artifacts:
+- path: build\*.nupkg
+  name: nuget

--- a/build.fsx
+++ b/build.fsx
@@ -13,6 +13,7 @@ let version = getArgOpt "-v" >> Option.defaultWith (fun () ->
     |> CreateProcess.redirectOutput
     |> Proc.run
     |> fun r -> r.Result.Output.Trim()
+)
 let cleanTest o = getArg "--clean-test" "false" o |> System.Boolean.TryParse ||> (&&)
 let forceVersion = getArgOpt "--force-version"
 

--- a/build.fsx
+++ b/build.fsx
@@ -8,7 +8,11 @@ open Fake.IO.FileSystemOperators
 open Utility
 
 // Command-line parameters
-let version = getArg "-v" "0.1.0"
+let version = getArgOpt "-v" >> Option.defaultWith (fun () ->
+    CreateProcess.fromRawCommand ".paket/nbgv" ["get-version"; "-v"; "SemVer2"]
+    |> CreateProcess.redirectOutput
+    |> Proc.run
+    |> fun r -> r.Result.Output.Trim()
 let cleanTest o = getArg "--clean-test" "false" o |> System.Boolean.TryParse ||> (&&)
 let forceVersion = getArgOpt "--force-version"
 

--- a/version.json
+++ b/version.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.5",
+    "nugetPackageVersion": {
+        "semVer": 2
+    },
+    "gitCommitIdShortAutoMinimum": 7,
+    "publicReleaseRefSpec": [
+        "^refs/heads/master$",
+        "^refs/heads/\\d+\\.\\d+$"
+    ]
+}


### PR DESCRIPTION
Same as https://github.com/fsbolero/Bolero/pull/36, but for these templates. You will be able to line up the major and minor numbers only, e.g. Bolero.Templates 0.5 for Bolero 0.5. The final digit will not be the same, but that should not matter.