### PR TITLE
Point to .NET 3.0-preview5 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To learn more, you can check [the documentation](https://fsbolero.io/docs).
 
 To get started, you need the following installed:
 
-* .NET Core SDK 2.1.403 or newer. Download it [here](https://www.microsoft.com/net/download/dotnet-core/2.1).
+* .NET Core SDK 3.0-preview5 or newer. Download it [here](https://dotnet.microsoft.com/download/dotnet-core/3.0).
 
 ## Creating a project based on this template
 


### PR DESCRIPTION
Updating the readme with information about the minimal version of dotnet. This is a copy of the https://github.com/fsbolero/Bolero/commit/d354c77833fadbde7a0022442667c33fa4f9d15a commit