### PR TITLE
Add meta viewport tag to head in client and server

### DIFF
--- a/content/application/src/Bolero.Template.Client/wwwroot/index.html
+++ b/content/application/src/Bolero.Template.Client/wwwroot/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bolero Application</title>
     <base href="/">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.4/css/bulma.min.css">

--- a/content/application/src/Bolero.Template.Server/Pages/_Host.cshtml
+++ b/content/application/src/Bolero.Template.Server/Pages/_Host.cshtml
@@ -6,6 +6,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bolero Application</title>
     <base href="/">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.4/css/bulma.min.css">


### PR DESCRIPTION
Allow template viewed on mobile devices to have better zoom level using meta viewport tag.

Before change (using Pixel 2 within dev tools in Vivaldi):

![Bolero Template before meta tag](https://user-images.githubusercontent.com/36001967/87241890-4b9f9000-c41f-11ea-87f6-504d4368d538.jpg)

After change:

![Bolero Template after meta tag](https://user-images.githubusercontent.com/36001967/87241892-55c18e80-c41f-11ea-9c4b-4a098d0684c4.jpg)
