### PR TITLE
Add dependencies to server.fsproj

### DIFF
--- a/content/application/src/Bolero.Template.Server/Bolero.Template.Server.fsproj
+++ b/content/application/src/Bolero.Template.Server/Bolero.Template.Server.fsproj
@@ -15,9 +15,13 @@
     <!-- //#if (hotreload_actual) -->
     <PackageReference Include="Bolero.HotReload.Server" Version="0.*" />
     <!-- //#endif -->
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.*" />
     <!-- //#if (razor_actual) -->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.*" />
     <!-- //#endif -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="3.1.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.*" />
+    <PackageReference Include="Microsoft.JSInterop" Version="3.1.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
On my system these are needed to avoid runtime errors when starting the server.
(Arch linux , dotnet version 3.1.300)