### PR TITLE
Fix --paket flag

### DIFF
--- a/content/application/.config/dotnet-tools.json
+++ b/content/application/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "5.241.6",
+      "version": "5.258.1",
       "commands": [
         "paket"
       ]

--- a/content/application/.template.config/template.json
+++ b/content/application/.template.config/template.json
@@ -208,6 +208,17 @@
       "args": {
         "redirectStandardOutput": "false",
         "executable": "dotnet",
+        "args": "tool restore"
+      },
+      "continueOnError": false
+    },
+    {
+      "condition": "(paket && OS == \"Windows_NT\")",
+      "description": "Convert project to Paket",
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "args": {
+        "redirectStandardOutput": "false",
+        "executable": "dotnet",
         "args": "paket convert-from-nuget --force"
       },
       "continueOnError": false

--- a/content/application/.template.config/template.json
+++ b/content/application/.template.config/template.json
@@ -202,7 +202,7 @@
   },
   "postActions": [
     {
-      "condition": "(paket && OS == \"Windows_NT\")",
+      "condition": "(paket)",
       "description": "Convert project to Paket",
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
@@ -213,7 +213,7 @@
       "continueOnError": false
     },
     {
-      "condition": "(paket && OS == \"Windows_NT\")",
+      "condition": "(paket)",
       "description": "Convert project to Paket",
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {

--- a/paket.template
+++ b/paket.template
@@ -4,6 +4,7 @@ authors IntelliFactory
 description
     A set of tools and libraries to run F# applications in WebAssembly using Blazor.
 files
+    content/**/.config/*                        ==> content
     content/**/.template.config/*               ==> content
     content/**/*.sln                            ==> content
     content/**/nuget.config                     ==> content


### PR DESCRIPTION
These commits do 3 things to fix and extend the --paket flag for the template:

1.  We update to the latest - at time of PR - release version of paket.
2.  We ensure that the `dotnet-tools.json` file from the template is included when we package the template, and that `dotnet tool restore` is invoked during `dotnet new` (1)
3. We remove the Windows-only restriction on the --paket flag (2)

(1) This results in two prompts to the user for approval during the process.  We could bring it down to 1 - by putting the two `dotnet` commands into a script and invoking that instead - but down that road seems to end up in more platform-specific stuff - like needing to suss out whether to invoke a shell script or a CMD file.

(2) I can't quite suss out why this restriction exists.  Removing it still works on Windows (my primary environment) - but also on my Ubuntu-via-WSL environment.

This should resolve #26 